### PR TITLE
Add image path support for recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # Cocktail Maschine
+
+## Bilder
+
+Rezeptbilder werden im Verzeichnis `assets/images/` abgelegt. Beim Hinzufügen eines Rezepts wird der relative Pfad zum Bild
+übergeben, z. B. `assets/images/cuba_libre.jpg`.

--- a/scripts/update_recipe_images.py
+++ b/scripts/update_recipe_images.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+import os
+import re
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+from src import database_manager
+
+IMAGE_DIR = os.path.join(os.path.dirname(__file__), '..', 'assets', 'images')
+RELATIVE_PREFIX = os.path.join('assets', 'images')
+
+def slugify(name: str) -> str:
+    return re.sub(r'[^a-z0-9]+', '_', name.lower()).strip('_')
+
+def update_image_paths():
+    conn = database_manager.create_connection()
+    if conn is None:
+        print("Keine Verbindung zur Datenbank.")
+        return
+    cur = conn.cursor()
+    cur.execute("SELECT recipe_id, name FROM recipes")
+    recipes = cur.fetchall()
+    for recipe_id, name in recipes:
+        slug = slugify(name)
+        updated = False
+        for ext in ('.jpg', '.png'):
+            filename = slug + ext
+            full_path = os.path.join(IMAGE_DIR, filename)
+            if os.path.exists(full_path):
+                rel_path = os.path.join(RELATIVE_PREFIX, filename)
+                cur.execute("UPDATE recipes SET image_path=? WHERE recipe_id=?", (rel_path, recipe_id))
+                print(f"{name}: {rel_path}")
+                updated = True
+                break
+        if not updated:
+            print(f"Kein Bild für Rezept '{name}' gefunden.")
+    conn.commit()
+    conn.close()
+
+if __name__ == '__main__':
+    update_image_paths()

--- a/src/database_manager.py
+++ b/src/database_manager.py
@@ -213,7 +213,11 @@ def get_all_ingredients():
 # ========== CRUD Recipes ==========
 # (unverändert)
 def add_recipe(name, description=None, image_path=None, instructions=None):
-    # ...
+    """Fügt ein Rezept hinzu.
+
+    Der optionale Parameter ``image_path`` erwartet einen relativen Pfad zum Bild,
+    z. B. ``assets/images/cuba_libre.jpg``.
+    """
     sql = ''' INSERT INTO recipes(name, description, image_path, instructions)
               VALUES(?,?,?,?) '''
     conn = create_connection()
@@ -549,8 +553,8 @@ def test_recipes():
     # ... (unverändert) ...
     print("\n--- Teste Recipe CRUD Funktionen ---")
     print("Füge Rezepte hinzu...")
-    add_recipe("Cuba Libre", "Ein Klassiker.", "cuba_libre.jpg", "Rum und Cola mischen, Limettensaft dazu.")
-    add_recipe("Screwdriver", "Simpel und gut.", "screwdriver.jpg", "Wodka und Orangensaft.")
+    add_recipe("Cuba Libre", "Ein Klassiker.", "assets/images/cuba_libre.jpg", "Rum und Cola mischen, Limettensaft dazu.")
+    add_recipe("Screwdriver", "Simpel und gut.", "assets/images/screwdriver.jpg", "Wodka und Orangensaft.")
     add_recipe("Cuba Libre") # Doppelt
 
     print("\nAlle Rezepte:")


### PR DESCRIPTION
## Summary
- Document and create `assets/images/` for storing recipe images
- Use relative image paths when adding recipes and clarify expected format
- Provide script to update existing recipes with image paths

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'kivy')*
- `python scripts/update_recipe_images.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6ef41a570832c82cf315f50e5fbff