### PR TITLE
Add image-based cocktail selection widget

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -10,6 +10,7 @@ from kivy.uix.label import Label
 from kivy.uix.textinput import TextInput
 from kivy.properties import NumericProperty, StringProperty, BooleanProperty, ListProperty, DictProperty
 from kivy.metrics import dp
+from ui.cocktail_image_button import CocktailImageButton
 
 # Standard Python Imports
 import yaml
@@ -78,13 +79,15 @@ class MainScreen(Screen): # Ebene 0
         # Schleife: Ebene 2 (8 spaces)
         for recipe in available_recipes:
             # Code in Schleife: Ebene 3 (12 spaces)
-            recipe_id, recipe_name, _, _, _ = recipe # Unpack recipe data
-            # Create a button for each cocktail
-            btn = Button(text=recipe_name,
-                         size_hint_y=None,
-                         height=button_height,
-                         font_size='20sp')
-            btn.recipe_id = recipe_id # Store recipe ID in the button instance
+            recipe_id, recipe_name, _, image_path, _ = recipe # Unpack recipe data
+            # Create an image button for each cocktail
+            btn = CocktailImageButton(
+                recipe_id=recipe_id,
+                source=image_path if image_path else '',
+                size_hint_y=None,
+                height=button_height,
+            )
+            btn.text = recipe_name  # Store recipe name for logging
             btn.bind(on_press=self.cocktail_selected) # Bind the on_press event
             cocktail_list_widget.add_widget(btn)
 

--- a/src/ui/cocktail_image_button.py
+++ b/src/ui/cocktail_image_button.py
@@ -1,0 +1,13 @@
+from kivy.uix.behaviors import ButtonBehavior
+from kivy.uix.image import Image
+from kivy.properties import NumericProperty, StringProperty
+
+
+class CocktailImageButton(ButtonBehavior, Image):
+    """Image-based button that stores a recipe ID."""
+    recipe_id = NumericProperty()
+    text = StringProperty("")
+
+    def __init__(self, recipe_id, **kwargs):
+        super().__init__(**kwargs)
+        self.recipe_id = recipe_id


### PR DESCRIPTION
## Summary
- Create `CocktailImageButton` widget combining `ButtonBehavior` and `Image` to hold a recipe ID.
- Replace text buttons with `CocktailImageButton` in `populate_cocktails` to display recipe images and bind selection handler.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a82309a0d0832cadb077f944616eca