### PR TITLE
Use image buttons for cocktail list

### DIFF
--- a/src/ui/cocktail_image_button.py
+++ b/src/ui/cocktail_image_button.py
@@ -1,0 +1,9 @@
+from kivy.uix.image import Image
+from kivy.uix.behaviors import ButtonBehavior
+from kivy.properties import NumericProperty
+
+
+class CocktailImageButton(ButtonBehavior, Image):
+    """Button that displays a cocktail image and stores a recipe id."""
+
+    recipe_id = NumericProperty()


### PR DESCRIPTION
## Summary
- Replace text buttons with new `CocktailImageButton` showing recipe images
- Compute cocktail grid size from image dimensions with placeholder fallback
- Remove repository PNG and rely on Kivy's built-in icon as fallback

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'kivy')*
- `pip install kivy==2.1.0` *(fails: command '/usr/bin/gcc' failed with exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a82460ad64832c8bb6fc2cb6b82a9e