### PR TITLE
Display cocktail selection as images

### DIFF
--- a/src/ui/__init__.py
+++ b/src/ui/__init__.py
@@ -1,0 +1,1 @@
+from .cocktail_image_button import CocktailImageButton

--- a/src/ui/cocktail_image_button.py
+++ b/src/ui/cocktail_image_button.py
@@ -1,0 +1,7 @@
+from kivy.uix.image import Image
+from kivy.uix.behaviors import ButtonBehavior
+
+
+class CocktailImageButton(ButtonBehavior, Image):
+    """A simple image button used to display cocktail images."""
+    pass


### PR DESCRIPTION
## Summary
- replace text buttons with new `CocktailImageButton` using recipe image paths
- size the cocktail grid based on the loaded images and fall back to a built-in Kivy icon when no image is available
- remove previously added placeholder image asset

## Testing
- `pip install kivy`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a825f08b28832c9c95dad62abd4b04